### PR TITLE
Revert "feat(hass): add skyconnect"

### DIFF
--- a/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
@@ -30,8 +30,6 @@ spec:
     image:
       repository: homeassistant/home-assistant
       tag: 2023.1.4
-    nodeSelector:
-      feature.node.kubernetes.io/usb-ff_10c4_ea60.present: 'true' # Require the Home Assistant SkyConnect
     env:
       TZ: "America/Chicago"
     ingress:
@@ -59,10 +57,6 @@ spec:
         server: 10.0.8.240
         path: /volume1/home-assistant
         readOnly: false
-      usb:
-        enabled: true
-        type: hostPath
-        hostPath: /dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_0a601e6e4bedec11b79a4340ad51a8b2-if00-port0
       # usb:
       #   enabled: true
       #   type: hostPath


### PR DESCRIPTION
The previous MR is resulting in HASS hanging unfortunately. Here's all I get from the logs:
```
kubectl logs home-assistant-6f6c75bdcb-m28kp -f
s6-rc: info: service s6rc-oneshot-runner: starting
s6-rc: info: service s6rc-oneshot-runner successfully started
s6-rc: info: service fix-attrs: starting
s6-rc: info: service fix-attrs successfully started
s6-rc: info: service legacy-cont-init: starting
s6-rc: info: service legacy-cont-init successfully started
s6-rc: info: service legacy-services: starting
services-up: info: copying legacy longrun home-assistant (no readiness notification)
s6-rc: info: service legacy-services successfully started
2023-01-17 20:56:11.717 WARNING (SyncWorker_2) [homeassistant.loader] We found a custom integration frigate which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
2023-01-17 20:56:11.719 WARNING (SyncWorker_2) [homeassistant.loader] We found a custom integration hacs which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
```

Backing this out.