### PR TITLE
Enable upgrade controller

### DIFF
--- a/kubernetes/apps/system-upgrade/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/kustomization.yaml
@@ -3,4 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  # - ./system-upgrade-controller/ks.yaml
+  - ./system-upgrade-controller/ks.yaml


### PR DESCRIPTION
Apparently this is an "optional component" so it was commented out by default. I noticed this after upgrading a plan to patch .1 k3s but noticing in kubectl that the cluster was still on .0. After this is merged, I expect that k3s is going to update.