### PR TITLE
Fix readarr chart version

### DIFF
--- a/kubernetes/apps/default/readarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/readarr/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: readarr
-      version: 16.3.2
+      version: 6.4.2
       sourceRef:
         kind: HelmRepository
         name: k8s-at-home


### PR DESCRIPTION
```
flux get source chart
NAME                              	REVISION	SUSPENDED	READY	MESSAGE                                                                                                                            
cert-manager-cert-manager         	v1.11.0 	False    	True 	pulled 'cert-manager' chart with version 'v1.11.0'                                                                                
default-echo-server               	1.3.2   	False    	True 	pulled 'app-template' chart with version '1.3.2'                                                                                  
default-jellyfin                  	9.5.3   	False    	True 	pulled 'jellyfin' chart with version '9.5.3'                                                                                      
default-lidarr                    	14.2.2  	False    	True 	pulled 'lidarr' chart with version '14.2.2'                                                                                       
default-mariadb                   	11.5.1  	False    	True 	pulled 'mariadb' chart with version '11.5.1'                                                                                      
default-nzbget                    	12.4.2  	False    	True 	pulled 'nzbget' chart with version '12.4.2'                                                                                       
default-prowlarr                  	4.5.2   	False    	True 	pulled 'prowlarr' chart with version '4.5.2'                                                                                      
default-radarr                    	16.3.2  	False    	True 	pulled 'radarr' chart with version '16.3.2'                                                                                       
default-readarr                   	        	False    	False	invalid chart reference: failed to get chart version for remote reference: no 'readarr' chart with version matching '16.3.2' found
default-sonarr                    	16.3.2  	False    	True 	pulled 'sonarr' chart with version '16.3.2'                                                                                       
flux-system-weave-gitops          	4.0.15  	False    	True 	pulled 'weave-gitops' chart with version '4.0.15'                                                                                 
kube-system-intel-gpu-plugin      	4.4.2   	False    	True 	pulled 'intel-gpu-plugin' chart with version '4.4.2'                                                                              
kube-system-metrics-server        	3.8.3   	False    	True 	pulled 'metrics-server' chart with version '3.8.3'                                                                                
kube-system-node-feature-discovery	0.12.1  	False    	True 	pulled 'node-feature-discovery' chart with version '0.12.1'                                                                       
kube-system-reloader              	v1.0.11 	False    	True 	pulled 'reloader' chart with version 'v1.0.11'                                                                                    
monitoring-kubernetes-dashboard   	6.0.0   	False    	True 	pulled 'kubernetes-dashboard' chart with version '6.0.0'                                                                          
networking-cloudflare-ddns        	1.3.2   	False    	True 	pulled 'app-template' chart with version '1.3.2'                                                                                  
networking-external-dns           	1.12.1  	False    	True 	pulled 'external-dns' chart with version '1.12.1'                                                                                 
networking-ingress-nginx          	4.5.2   	False    	True 	pulled 'ingress-nginx' chart with version '4.5.2'                                                                                 
networking-k8s-gateway            	2.0.2   	False    	True 	pulled 'k8s-gateway' chart with version '2.0.2'                                                                                   
networking-metallb                	0.13.9  	False    	True 	pulled 'metallb' chart with version '0.13.9'  
```

Fix it!